### PR TITLE
Use of AbstractService::service() to determine service name

### DIFF
--- a/src/Gigablah/Silex/OAuth/EventListener/UserInfoListener.php
+++ b/src/Gigablah/Silex/OAuth/EventListener/UserInfoListener.php
@@ -39,7 +39,9 @@ class UserInfoListener implements EventSubscriberInterface
         $token = $event->getToken();
         $service = $token->getService();
         $oauthService = $this->registry->getService($service);
-        $accessToken = $oauthService->getStorage()->retrieveAccessToken(OAuthServiceRegistry::getServiceName($oauthService));
+
+        $serviceName = ($oauthService instanceof \OAuth\Common\Service\AbstractService)?$oauthService->service():OAuthServiceRegistry::getServiceName($oauthService);
+        $accessToken = $oauthService->getStorage()->retrieveAccessToken($serviceName);
         $token->setAccessToken($accessToken);
 
         if (false === $rawUserInfo = json_decode($oauthService->request($this->config[$service]['user_endpoint']), true)) {

--- a/src/Gigablah/Silex/OAuth/Security/Firewall/OAuthAuthenticationListener.php
+++ b/src/Gigablah/Silex/OAuth/Security/Firewall/OAuthAuthenticationListener.php
@@ -135,7 +135,8 @@ class OAuthAuthenticationListener extends AbstractAuthenticationListener
 
             if ($oauthService instanceof OAuth1ServiceInterface) {
                 try {
-                    $token = $oauthService->getStorage()->retrieveAccessToken(OAuthServiceRegistry::getServiceName($oauthService));
+                    $serviceName = ($oauthService instanceof \OAuth\Common\Service\AbstractService)?$oauthService->service():OAuthServiceRegistry::getServiceName($oauthService);
+                    $token = $oauthService->getStorage()->retrieveAccessToken($serviceName);
                 } catch (StorageException $exception) {
                     throw new AuthenticationException('Could not retrieve access token.', null, $exception);
                 }


### PR DESCRIPTION
In some case, oauth service name can be overriden by developer, so we need to have an unified way to get service name between gigablah/silex-oauth and lusitanian/oauth

thanks 
