### PR TITLE
Fixed InvalidArgumentException with new account on github.com

### DIFF
--- a/src/Gigablah/Silex/OAuth/EventListener/UserInfoListener.php
+++ b/src/Gigablah/Silex/OAuth/EventListener/UserInfoListener.php
@@ -51,7 +51,7 @@ class UserInfoListener implements EventSubscriberInterface
         $userInfo = array();
         $fieldMap = array(
             'id' => array('id'),
-            'name' => array('name', 'username', 'screen_name'),
+            'name' => array('name', 'username', 'screen_name', 'login'),
             'email' => array('email', function ($data, $provider) {
                 if ('twitter' === $provider) {
                     return $data['screen_name'] . '@twitter.com';


### PR DESCRIPTION
On github.com new account does not any fields of those specified to guess name of user.

Here's the exception thrown:

> InvalidArgumentException: $user must be an instanceof UserInterface, an object implementing a __toString method, or a primitive string.
