### PR TITLE
Handle of oAuth response with error.

### DIFF
--- a/src/EventListener/UserInfoListener.php
+++ b/src/EventListener/UserInfoListener.php
@@ -65,7 +65,7 @@ class UserInfoListener implements EventSubscriberInterface
 
     protected function defaultUserCallback($token, $rawUserInfo, $service)
     {
-        if (!is_array($rawUserInfo)) {
+        if (!is_array($rawUserInfo) || isset($rawUserInfo['error'])) {
             return;
         }
 


### PR DESCRIPTION
To prevent:
 InvalidArgumentException: $user must be an instanceof UserInterface, an object im
plementing a __toString method, or a primitive string. (uncaught exception) at /vendor/sy
mfony/security/Core/Authentication/Token/AbstractToken.php line 94 {"exception":"[object](InvalidArgumentException%28code
: 0%29: $user must be an instanceof UserInterface, an object implementing a __toString method, or a primitive string. at/vendor/symfony/security/Core/Authentication/Token/AbstractToken.php:94)"} []

Caused by oauth returned Error instead of user data like this:

array('error' => array('message' => 'Invalid OAuth access token.', 'type' => 'OAuthException', 'code' => '190', 'fbtrace_id' => 'HZmpbcgRi1l'))
